### PR TITLE
Automatic update of GraphQL-Parser to 3.0.0

### DIFF
--- a/CvApi/CvApi.csproj
+++ b/CvApi/CvApi.csproj
@@ -43,8 +43,8 @@
       <HintPath>..\packages\GraphQL.0.15.1.678\lib\net45\GraphQL.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="GraphQL-Parser, Version=2.0.0.17, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\GraphQL-Parser.2.0.0\lib\net45\GraphQL-Parser.dll</HintPath>
+    <Reference Include="GraphQL-Parser, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\GraphQL-Parser.3.0.0\lib\net45\GraphQL-Parser.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/CvApi/packages.config
+++ b/CvApi/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GraphQL" version="0.15.1.678" targetFramework="net452" />
-  <package id="GraphQL-Parser" version="2.0.0" targetFramework="net452" />
+  <package id="GraphQL-Parser" version="3.0.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />


### PR DESCRIPTION
NuKeeper has generated a major update of `GraphQL-Parser` to `3.0.0` from `2.0.0`
`GraphQL-Parser 3.0.0` was published at `2017-09-08T20:19:51Z`, 1 year and 2 months ago

1 project update:
Updated `CvApi\packages.config` to `GraphQL-Parser` `3.0.0` from `2.0.0`

[GraphQL-Parser 3.0.0 on NuGet.org](https://www.nuget.org/packages/GraphQL-Parser/3.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
