### PR TITLE
Automatic update of Microsoft.IdentityModel.Logging to 5.3.0

### DIFF
--- a/CvApi/CvApi.csproj
+++ b/CvApi/CvApi.csproj
@@ -48,8 +48,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.IdentityModel.Logging, Version=1.1.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Logging.1.1.3\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.5.3.0\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.1.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/CvApi/packages.config
+++ b/CvApi/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net452" />
-  <package id="Microsoft.IdentityModel.Logging" version="1.1.3" targetFramework="net452" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.3.0" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.1.3" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.IdentityModel.Logging` to `5.3.0` from `1.1.3`
`Microsoft.IdentityModel.Logging 5.3.0` was published at `2018-10-05T22:01:35Z`, 1 month ago

1 project update:
Updated `CvApi\packages.config` to `Microsoft.IdentityModel.Logging` `5.3.0` from `1.1.3`

[Microsoft.IdentityModel.Logging 5.3.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.IdentityModel.Logging/5.3.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
